### PR TITLE
[Testing] Add a semantic check for Worshare construct

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -68,11 +68,23 @@ public:
     if (const auto *e{GetExpr(context_, expr)}) {
       for (const Symbol &symbol : evaluate::CollectSymbols(*e)) {
         const Symbol &root{GetAssociationRoot(symbol)};
-        if (IsFunction(root) && !IsElementalProcedure(root)) {
-          context_.Say(expr.source,
-              "User defined non-ELEMENTAL function "
-              "'%s' is not allowed in a WORKSHARE construct"_err_en_US,
-              root.name());
+        if (IsFunction(root)) {
+          std::string attrs{""};
+          if (!IsElementalProcedure(root)) {
+            attrs = " non-ELEMENTAL";
+          }
+          if (symbol.attrs().test(Attr::IMPURE)) {
+            if (attrs != "") {
+              attrs = "," + attrs;
+            }
+            attrs = " IMPURE" + attrs;
+          }
+          if (attrs != "") {
+            context_.Say(expr.source,
+                "User defined%s function '%s' is not allowed in a "
+                "WORKSHARE construct"_err_en_US,
+                attrs, root.name());
+          }
         }
       }
     }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -69,7 +69,7 @@ public:
       for (const Symbol &symbol : evaluate::CollectSymbols(*e)) {
         const Symbol &root{GetAssociationRoot(symbol)};
         if (IsFunction(root)) {
-          std::string attrs{""};
+          std::string attrs;
           if (!IsElementalProcedure(root)) {
             attrs = " non-ELEMENTAL";
           }

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -88,7 +88,6 @@ public:
         }
       }
     }
-    return false;
   }
 
 private:

--- a/flang/test/Semantics/OpenMP/workshare02.f90
+++ b/flang/test/Semantics/OpenMP/workshare02.f90
@@ -9,6 +9,14 @@ module my_mod
   integer function my_func()
     my_func = 10
   end function my_func
+
+  impure integer function impure_my_func()
+    impure_my_func_ = 20
+  end function impure_my_func
+
+  impure elemental integer function impure_ele_my_func()
+    impure_ele_my_func = 20
+  end function impure_ele_my_func
 end module my_mod
 
 subroutine workshare(aa, bb, cc, dd, ee, ff, n)
@@ -61,6 +69,16 @@ subroutine workshare(aa, bb, cc, dd, ee, ff, n)
   j = j - my_func()
   !$omp end atomic
 
+  !ERROR: User defined IMPURE, non-ELEMENTAL function 'impure_my_func' is not allowed in a WORKSHARE construct
+  cc = impure_my_func()
+  !ERROR: User defined IMPURE function 'impure_ele_my_func' is not allowed in a WORKSHARE construct
+  aa(1) = impure_ele_my_func()
+
   !$omp end workshare
+
+  !$omp workshare
+    j = j + 1
+  !ERROR: At most one NOWAIT clause can appear on the END WORKSHARE directive
+  !$omp end workshare nowait nowait
 
 end subroutine workshare

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -1162,7 +1162,7 @@ def OMP_Workshare : Directive<"workshare"> {
   let category = CA_Executable;
 }
 def OMP_EndWorkshare : Directive<"end workshare"> {
-  let allowedClauses = [
+  let allowedOnceClauses = [
     VersionedClause<OMPC_NoWait>,
   ];
   let leafConstructs = OMP_Workshare.leafConstructs;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error messages for OpenMP constructs to provide clearer guidance.
  - New checks for nested OpenMP constructs to enforce proper usage.
  - Introduction of new impure functions for testing OpenMP rules.

- **Bug Fixes**
  - Improved enforcement of OpenMP rules regarding user-defined functions in workshare constructs, leading to more accurate error reporting.

- **Documentation**
  - Updated directive definitions for `OMP_EndWorkshare`, clarifying allowed clauses and usage restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->